### PR TITLE
All: add CSP exceptions for loading klavika font from typekit

### DIFF
--- a/jquery/functions.php
+++ b/jquery/functions.php
@@ -289,9 +289,14 @@ function twentyeleven_content_security_policy() {
 	$report_url = 'https://csp-report-api.openjs-foundation.workers.dev/';
 	$policy = array(
 		'default-src' => "'self'",
-		'script-src' => "'self' code.jquery.com",
-		'style-src' => "'self' code.jquery.com",
+		// Allow scripts and inline scripts for typekit
+		'script-src' => "'self' 'unsafe-inline' code.jquery.com use.typekit.net",
+		// Allow inline styles for typekit
+		'style-src' => "'self' 'unsafe-inline' code.jquery.com",
+		// Leaving out typekit img-src, which only loads the p.gif for analytics
 		'img-src' => "'self' code.jquery.com",
+		// Allow fonts from typekit
+		'font-src' => "'self' use.typekit.net",
 		'object-src' => "'none'",
 		'frame-ancestors' => "'none'",
 		'block-all-mixed-content' => '',


### PR DESCRIPTION
We switched to self-hosted Cairo on the other wordpress sites, but I'm fine allowing typekit on blogs until [the switch to jquery-wp-content](https://github.com/jquery/infrastructure-puppet/issues/17).

Ref https://github.com/jquery/infrastructure-puppet/issues/54