### PR TITLE
All: add CSP exceptions for remote images

### DIFF
--- a/jquery/functions.php
+++ b/jquery/functions.php
@@ -293,8 +293,10 @@ function twentyeleven_content_security_policy() {
 		'script-src' => "'self' 'unsafe-inline' code.jquery.com use.typekit.net",
 		// Allow inline styles for typekit
 		'style-src' => "'self' 'unsafe-inline' code.jquery.com",
+		// Allow images from about:blank, *.cloudfront.net, events.jquery.org, and openjsf.org
+		// Allow images from *.twimg.com, gruntjs.com and *.imgur.com
 		// Leaving out typekit img-src, which only loads the p.gif for analytics
-		'img-src' => "'self' code.jquery.com",
+		'img-src' => "'self' about: *.cloudfront.net events.jquery.org openjsf.org *.twimg.com gruntjs.com *.imgur.com code.jquery.com",
 		// Allow fonts from typekit
 		'font-src' => "'self' use.typekit.net",
 		'object-src' => "'none'",


### PR DESCRIPTION
Add CSP exceptions for images loaded on the following pages:

https://blog.jquery.com/category/events/
https://blog.jquery.com/category/foundation/
https://blog.jquery.com/category/projects/
https://blog.jquery.com/category/weekly-news/

Ref https://github.com/jquery/infrastructure-puppet/issues/54
Closes gh-10