### PR TITLE
All: switch CSP headers from report-only to enforced

### DIFF
--- a/jquery/functions.php
+++ b/jquery/functions.php
@@ -314,7 +314,7 @@ function twentyeleven_content_security_policy() {
 	}
 
 	header( 'Reporting-Endpoints: csp-endpoint="' . $report_url . '"' );
-	header( 'Content-Security-Policy-Report-Only: ' . $policy_string );
+	header( 'Content-Security-Policy: ' . $policy_string );
 }
 
 add_action( 'send_headers', 'twentyeleven_content_security_policy' );


### PR DESCRIPTION
I checked the last 24 hours and I think we're good to switch to enforced headers. AFAIK, we'll then be able to close the CSP ticket!

Ref https://github.com/jquery/infrastructure-puppet/issues/54